### PR TITLE
Removes the Id interface requirement.

### DIFF
--- a/docs/facade.md
+++ b/docs/facade.md
@@ -14,8 +14,8 @@ The facade contains common functions for storage and retrieval of entities from 
 
 The functions have some common options that they use.
 
-- [Entity](./options.md#entity)
 - [Id](./options.md#id)
+- [Entity](./options.md#entity)
 - [Patch](./options.md#patch)
 - [Filter](./options.md#filter)
 - [Sort](./options.md#sort)

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -28,7 +28,7 @@ Creates a new entity using the `entity` option if no entity exists that matches 
 
 ```ts
 const { entity } = await facade.createEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
   entity: { id: 'example_id', foo: 'bar' },
 });
 ```
@@ -63,7 +63,7 @@ Retrieves a single entity that matches the `id` option.
 
 ```ts
 const { entity } = await facade.getEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
 });
 ```
 
@@ -74,7 +74,7 @@ For an entity that matches the `id` option, it changes all of an entity's proper
 
 ```ts
 const { entity } = await facade.overwriteEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
   entity: { id: 'example_id', foo: 'bar' },
 });
 ```
@@ -86,7 +86,7 @@ For an entity that matches the `id` option, it changes some of an entity's prope
 
 ```ts
 const { entity } = await facade.patchEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
   patch: { foo: 'bar' },
 });
 ```
@@ -109,7 +109,7 @@ Removes an entity that matches the `id` option.
 
 ```ts
 await facade.removeEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
 });
 ```
 
@@ -120,7 +120,7 @@ Creates an entity when no entity exists that matches the `id` option. Otherwise,
 
 ```ts
 await facade.upsertEntity({
-  id: { id: 'example_id' },
+  id: 'example_id',
   entity: { id: 'example_id', foo: 'bar' },
 });
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -10,23 +10,17 @@ The [facade](./facade.md) [functions](./functions.md) have some common options t
 - [Pagination](#pagination)
 
 ### Id
-This is an object that contains only the properties required to distinctly identify an entity. In most common cases there is a single property making the [unique key](https://en.wikipedia.org/wiki/Unique_key) so it will likely just contain the `id` property. However, for entities with multiple properties making the unique key it will contain those properties.
-
-This interface is user-defined hence not contained in this package, the interface below demonstrates what this will look like in most cases.
-
-```ts
-interface Id {
-  readonly id: string;
-}
-```
+This is a string that uniquely identifies an entity.
 
 ### Entity
 This is an object that contains all of the entity's properties. The word "entity" has been borrowed from [Entity-Relationship Models/Diagrams](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model) and has been used instead of the word "model" to avoid confusion with MVC.
 
-This interface is user-defined hence not contained in this package, the interface below demonstrates what this might look like for a todo entity and extends the [Id interface from the Id example](#id).
+This interface is user-defined hence not contained in this package, the interface below demonstrates what this might look like for a todo entity and extends the Entity interface in this package which contains the `id` property.
 
 ```ts
-interface TodoEntity extends Id {
+import Entity from '@js-entity-repos/core/dist/types/Entity';
+
+interface TodoEntity extends Entity {
   readonly description: string;
   readonly completed: boolean;
 }
@@ -44,7 +38,7 @@ This is an object where a key represents the entity property to be sorted and th
 This package contains the [TypeScript Sort type definition](../src/types/Sort.ts).
 
 ### Pagination
-This is an object with three properties, `limit`, `forward`, and `cursor`. The `limit` property defines how many entities to return (maximum). The `forward` property defines whether the entities should be iterate through the entities forwards (when `true`) or backwards (when `false`) from the `cursor`. The `cursor` property defines where to start iterating through the entities.
+This is an object with three properties, `limit`, `forward`, and `cursor`. The `limit` property defines how many entities to return (maximum). The `forward` property defines whether the entities should be iterate through the entities forwards (when `true`) or backwards (when `false`) from the `cursor`. The `cursor` property defines where to start iterating through the entities. Cursors have been used instead of `skip` and `limit` to avoid the [pagination issues discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
 
 Concrete implementations of the facade can use the [`createCursorFromEntity`](../src/utils/createCursorFromEntity) and [`createPaginationFilter`](../src/utils/createPaginationFilter) util functions to generate cursors.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -40,6 +40,6 @@ This package contains the [TypeScript Sort type definition](../src/types/Sort.ts
 ### Pagination
 This is an object with three properties, `limit`, `forward`, and `cursor`. The `limit` property defines how many entities to return (maximum). The `forward` property defines whether the entities should be iterated through forwards (when `true`) or backwards (when `false`) from the `cursor`. The `cursor` property defines where to start iterating through the entities. Cursors have been used instead of `skip` and `limit` to avoid the [pagination issues discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
 
-Concrete implementations of the facade can use the [`createCursorFromEntity`](../src/utils/createCursorFromEntity) and [`createPaginationFilter`](../src/utils/createPaginationFilter) util functions to generate cursors.
+Concrete implementations of the facade can use the [`createCursorFromEntity`](../src/utils/createCursorFromEntity) and [`createPaginationFilter`](../src/utils/createPaginationFilter) utility functions to generate cursors.
 
 This package also contains the [TypeScript Pagination interface](../src/types/Pagination.ts) and the [TypeScript Cursor type definition](../src/types/Cursor.ts).

--- a/docs/options.md
+++ b/docs/options.md
@@ -38,7 +38,7 @@ This is an object where a key represents the entity property to be sorted and th
 This package contains the [TypeScript Sort type definition](../src/types/Sort.ts).
 
 ### Pagination
-This is an object with three properties, `limit`, `forward`, and `cursor`. The `limit` property defines how many entities to return (maximum). The `forward` property defines whether the entities should be iterate through the entities forwards (when `true`) or backwards (when `false`) from the `cursor`. The `cursor` property defines where to start iterating through the entities. Cursors have been used instead of `skip` and `limit` to avoid the [pagination issues discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
+This is an object with three properties, `limit`, `forward`, and `cursor`. The `limit` property defines how many entities to return (maximum). The `forward` property defines whether the entities should be iterated through forwards (when `true`) or backwards (when `false`) from the `cursor`. The `cursor` property defines where to start iterating through the entities. Cursors have been used instead of `skip` and `limit` to avoid the [pagination issues discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
 
 Concrete implementations of the facade can use the [`createCursorFromEntity`](../src/utils/createCursorFromEntity) and [`createPaginationFilter`](../src/utils/createPaginationFilter) util functions to generate cursors.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -15,7 +15,7 @@ This is a string that uniquely identifies an entity.
 ### Entity
 This is an object that contains all of the entity's properties. The word "entity" has been borrowed from [Entity-Relationship Models/Diagrams](https://en.wikipedia.org/wiki/Entity%E2%80%93relationship_model) and has been used instead of the word "model" to avoid confusion with MVC.
 
-This interface is user-defined hence not contained in this package, the interface below demonstrates what this might look like for a todo entity and extends the Entity interface in this package which contains the `id` property.
+This interface is user-defined hence not contained in this package, the interface below demonstrates what this might look like for a todo entity and extends the [TypeScript Entity interface](../src/types/Entity.ts) defined in this package which contains the `id` property.
 
 ```ts
 import Entity from '@js-entity-repos/core/dist/types/Entity';

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 The project has some similarities with parts of the [FeathersJS framework](feathersjs.com), but unfortunately I've found the following issues with FeathersJS.
 
 - Their pagination uses skip and limit instead of cursors which causes [issues as discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
-- Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
+- Their service interface is missing some functions provided in the [Facade](./docs/facade.md) here.
 - Their errors take messages instead of parameters making it harder to support localisation.
 
 ### Thanks

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The project has some similarities with parts of the [FeathersJS framework](feath
 - Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
 - Their errors take messages instead of parameters making it harder to support localisation.
 
-Thanks to colleagues at @HT2-Labs that have used and helped sanity check this project.
+Thanks to colleagues at [HT2-Labs](https://www.ht2labs.com) that have used and helped sanity check this project.
 
 - [James](https://github.com/ht2)
 - [Mariusz](https://github.com/mariocoski)

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ### FeathersJS
 The project has some similarities with parts of the [FeathersJS framework](feathersjs.com), but unfortunately I've found the following issues with FeathersJS.
 
-- Their pagination uses skip and limit not cursors which causes issues as discussed by [Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
+- Their pagination uses skip and limit instead of cursors which causes [issues as discussed by Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
 - Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
 - Their errors take messages instead of parameters making it harder to support localisation.
 

--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,27 @@
 ### Usage
 - Install it with `npm i @js-entity-repos/core`.
 - Understand it by reading the [documenation](./docs/facade.md).
+
+### Thanks
+This project has been inspired by the work of many people, but especially the following people.
+
+- [Martin Fowler](https://en.wikipedia.org/wiki/Martin_Fowler)
+- [Robert Martin](https://en.wikipedia.org/wiki/Robert_Cecil_Martin)
+- [Taylor Otwell](http://taylorotwell.com/)
+- [Craig Larman](https://en.wikipedia.org/wiki/Craig_Larman)
+- [Erich Gamma](https://en.wikipedia.org/wiki/Erich_Gamma)
+- [Richard Helm](http://c2.com/cgi/wiki?RichardHelm)
+- [Ralph Johnson](https://en.wikipedia.org/wiki/Ralph_Johnson_(computer_scientist))
+- [John Vlissides](https://en.wikipedia.org/wiki/John_Vlissides)
+
+The project has some similarities with parts of the [FeathersJS framework](feathersjs.com), but unfortunately I've found the following issues with FeathersJS.
+
+- Their pagination uses skip and limit not cursors which causes issues as discussed by [Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
+- Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
+- Their errors take messages instead of parameters making it harder to support localisation.
+
+Thanks to colleagues at @HT2-Labs that have used and helped sanity check this project.
+
+- [James](https://github.com/ht2)
+- [Mariusz](https://github.com/mariocoski)
+- [Pete](https://github.com/ee0pdt)

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The project has some similarities with parts of the [FeathersJS framework](feath
 - Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
 - Their errors take messages instead of parameters making it harder to support localisation.
 
-Thanks to colleagues at [HT2-Labs](https://www.ht2labs.com) that have used and helped sanity check this project.
+Thanks to colleagues at [HT2 Labs](https://www.ht2labs.com) that have used and helped sanity check this project.
 
 - [James](https://github.com/ht2)
 - [Mariusz](https://github.com/mariocoski)

--- a/readme.md
+++ b/readme.md
@@ -5,26 +5,12 @@
 - Install it with `npm i @js-entity-repos/core`.
 - Understand it by reading the [documenation](./docs/facade.md).
 
-### Thanks
-This project has been inspired by the work of many people, but especially the following people.
-
-- [Martin Fowler](https://en.wikipedia.org/wiki/Martin_Fowler)
-- [Robert Martin](https://en.wikipedia.org/wiki/Robert_Cecil_Martin)
-- [Taylor Otwell](http://taylorotwell.com/)
-- [Craig Larman](https://en.wikipedia.org/wiki/Craig_Larman)
-- [Erich Gamma](https://en.wikipedia.org/wiki/Erich_Gamma)
-- [Richard Helm](http://c2.com/cgi/wiki?RichardHelm)
-- [Ralph Johnson](https://en.wikipedia.org/wiki/Ralph_Johnson_(computer_scientist))
-- [John Vlissides](https://en.wikipedia.org/wiki/John_Vlissides)
-
+### FeathersJS
 The project has some similarities with parts of the [FeathersJS framework](feathersjs.com), but unfortunately I've found the following issues with FeathersJS.
 
 - Their pagination uses skip and limit not cursors which causes issues as discussed by [Rakhitha Nimesh](https://www.sitepoint.com/paginating-real-time-data-cursor-based-pagination/).
 - Their service interface is missing some methods provided in the [Facade](./docs/facade.md) here.
 - Their errors take messages instead of parameters making it harder to support localisation.
 
-Thanks to colleagues at [HT2 Labs](https://www.ht2labs.com) that have used and helped sanity check this project.
-
-- [James](https://github.com/ht2)
-- [Mariusz](https://github.com/mariocoski)
-- [Pete](https://github.com/ee0pdt)
+### Thanks
+Thanks to [James](https://github.com/ht2), [Mariusz](https://github.com/mariocoski), and [Pete](https://github.com/ee0pdt) at [HT2 Labs](https://www.ht2labs.com) for their feedback.

--- a/src/Facade.ts
+++ b/src/Facade.ts
@@ -7,15 +7,16 @@ import PatchEntity from './signatures/PatchEntity';
 import RemoveEntities from './signatures/RemoveEntities';
 import RemoveEntity from './signatures/RemoveEntity';
 import UpsertEntity from './signatures/UpsertEntity';
+import Entity from './types/Entity';
 
-export default interface Facade<Id, Entity extends Id> {
-  readonly getEntity: GetEntity<Id, Entity>;
-  readonly createEntity: CreateEntity<Id, Entity>;
-  readonly overwriteEntity: OverwriteEntity<Id, Entity>;
-  readonly patchEntity: PatchEntity<Id, Entity>;
-  readonly removeEntity: RemoveEntity<Id>;
-  readonly getEntities: GetEntities<Entity>;
-  readonly countEntities: CountEntities<Entity>;
-  readonly removeEntities: RemoveEntities<Entity>;
-  readonly upsertEntity: UpsertEntity<Id, Entity>;
+export default interface Facade<E extends Entity> {
+  readonly getEntity: GetEntity<E>;
+  readonly createEntity: CreateEntity<E>;
+  readonly overwriteEntity: OverwriteEntity<E>;
+  readonly patchEntity: PatchEntity<E>;
+  readonly removeEntity: RemoveEntity;
+  readonly getEntities: GetEntities<E>;
+  readonly countEntities: CountEntities<E>;
+  readonly removeEntities: RemoveEntities<E>;
+  readonly upsertEntity: UpsertEntity<E>;
 }

--- a/src/errors/ConflictingEntityError.ts
+++ b/src/errors/ConflictingEntityError.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-class
 import { BaseError } from 'make-error';
 
-export default class ConflictingEntityError<Id> extends BaseError {
-  constructor(public entityName: string, public entityId: Id) {
+export default class ConflictingEntityError extends BaseError {
+  constructor(public entityName: string, public entityId: string) {
     super();
   }
 }

--- a/src/errors/MissingEntityError.ts
+++ b/src/errors/MissingEntityError.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-class
 import { BaseError } from 'make-error';
 
-export default class MissingEntityError<Id> extends BaseError {
-  constructor(public entityName: string, public entityId: Id) {
+export default class MissingEntityError extends BaseError {
+  constructor(public entityName: string, public entityId: string) {
     super();
   }
 }

--- a/src/signatures/CountEntities.ts
+++ b/src/signatures/CountEntities.ts
@@ -1,13 +1,14 @@
+import Entity from '../types/Entity';
 import Filter from '../types/Filter';
 
-export interface Opts<Entity> {
-  readonly filter: Filter<Entity>;
+export interface Opts<E extends Entity> {
+  readonly filter: Filter<E>;
 }
 
 export interface Result {
   readonly count: number;
 }
 
-export type Signature<Entity> = (opts: Opts<Entity>) => Promise<Result>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result>;
 
 export default Signature;

--- a/src/signatures/CreateEntity.ts
+++ b/src/signatures/CreateEntity.ts
@@ -1,13 +1,14 @@
-export interface Opts<Id, Entity extends Id> {
-  readonly id: Id;
-  readonly entity: Entity;
+import Entity from '../types/Entity';
+
+export interface Opts<E extends Entity> {
+  readonly id: string;
+  readonly entity: E;
 }
 
-export interface Result<Entity> {
-  readonly entity: Entity;
+export interface Result<E extends Entity> {
+  readonly entity: E;
 }
 
-export type Signature<Id, Entity extends Id> =
-  (opts: Opts<Id, Entity>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/signatures/GetEntities.ts
+++ b/src/signatures/GetEntities.ts
@@ -1,20 +1,21 @@
 import Cursor from '../types/Cursor';
+import Entity from '../types/Entity';
 import Filter from '../types/Filter';
 import Pagination from '../types/Pagination';
 import Sort from '../types/Sort';
 
-export interface Opts<Entity> {
-  readonly filter: Filter<Entity>;
-  readonly sort: Sort<Entity>;
+export interface Opts<E extends Entity> {
+  readonly filter: Filter<E>;
+  readonly sort: Sort<E>;
   readonly pagination: Pagination;
 }
 
-export interface Result<Entity> {
-  readonly entities: Entity[];
+export interface Result<E extends Entity> {
+  readonly entities: E[];
   readonly nextCursor: Cursor;
   readonly previousCursor: Cursor;
 }
 
-export type Signature<Entity> = (opts: Opts<Entity>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/signatures/GetEntity.ts
+++ b/src/signatures/GetEntity.ts
@@ -1,11 +1,13 @@
-export interface Opts<Id> {
-  readonly id: Id;
+import Entity from '../types/Entity';
+
+export interface Opts {
+  readonly id: string;
 }
 
-export interface Result<Entity> {
-  readonly entity: Entity;
+export interface Result<E extends Entity> {
+  readonly entity: E;
 }
 
-export type Signature<Id, Entity extends Id> = (opts: Opts<Id>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/signatures/OverwriteEntity.ts
+++ b/src/signatures/OverwriteEntity.ts
@@ -1,13 +1,14 @@
-export interface Opts<Id, Entity> {
-  readonly id: Id;
-  readonly entity: Entity;
+import Entity from '../types/Entity';
+
+export interface Opts<E extends Entity> {
+  readonly id: string;
+  readonly entity: E;
 }
 
-export interface Result<Entity> {
-  readonly entity: Entity;
+export interface Result<E extends Entity> {
+  readonly entity: E;
 }
 
-export type Signature<Id, Entity extends Id> =
-  (opts: Opts<Id, Entity>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/signatures/PatchEntity.ts
+++ b/src/signatures/PatchEntity.ts
@@ -1,13 +1,14 @@
-export interface Opts<Id, Entity> {
-  readonly id: Id;
-  readonly patch: Partial<Entity>;
+import Entity from '../types/Entity';
+
+export interface Opts<E extends Entity> {
+  readonly id: string;
+  readonly patch: Partial<E>;
 }
 
-export interface Result<Entity> {
-  readonly entity: Entity;
+export interface Result<E extends Entity> {
+  readonly entity: E;
 }
 
-export type Signature<Id, Entity extends Id> =
-  (opts: Opts<Id, Entity>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/signatures/RemoveEntities.ts
+++ b/src/signatures/RemoveEntities.ts
@@ -1,11 +1,12 @@
+import Entity from '../types/Entity';
 import Filter from '../types/Filter';
 
-export interface Opts<Entity> {
-  readonly filter: Filter<Entity>;
+export interface Opts<E extends Entity> {
+  readonly filter: Filter<E>;
 }
 
 export type Result = void;
 
-export type Signature<Entity> = (opts: Opts<Entity>) => Promise<Result>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result>;
 
 export default Signature;

--- a/src/signatures/RemoveEntity.ts
+++ b/src/signatures/RemoveEntity.ts
@@ -1,9 +1,9 @@
-export interface Opts<Id> {
-  readonly id: Id;
+export interface Opts {
+  readonly id: string;
 }
 
 export type Result = void;
 
-export type Signature<Id> = (opts: Opts<Id>) => Promise<Result>;
+export type Signature = (opts: Opts) => Promise<Result>;
 
 export default Signature;

--- a/src/signatures/UpsertEntity.ts
+++ b/src/signatures/UpsertEntity.ts
@@ -1,13 +1,14 @@
-export interface Opts<Id, Entity> {
-  readonly id: Id;
-  readonly entity: Entity;
+import Entity from '../types/Entity';
+
+export interface Opts<E extends Entity> {
+  readonly id: string;
+  readonly entity: E;
 }
 
-export interface Result<Entity> {
-  readonly entity: Entity;
+export interface Result<E extends Entity> {
+  readonly entity: E;
 }
 
-export type Signature<Id, Entity extends Id> =
-  (opts: Opts<Id, Entity>) => Promise<Result<Entity>>;
+export type Signature<E extends Entity> = (opts: Opts<E>) => Promise<Result<E>>;
 
 export default Signature;

--- a/src/tests/countEntities/test.ts
+++ b/src/tests/countEntities/test.ts
@@ -2,9 +2,9 @@ import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import Facade from '../../Facade';
 import filterTest from '../utils/filterTest';
-import { TestEntity, TestId } from '../utils/testEntity';
+import { TestEntity } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('countEntities', () => {
     filterTest({
       assertAllEntitiesFilter: async (filter) => {

--- a/src/tests/createEntity/test.ts
+++ b/src/tests/createEntity/test.ts
@@ -2,9 +2,9 @@ import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import ConflictingEntityError from '../../errors/ConflictingEntityError';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('createEntity', () => {
     it('should not error when identifier does not exist', async () => {
       await facade.createEntity({ id: testId, entity: testEntity });

--- a/src/tests/getEntities/filterTest.ts
+++ b/src/tests/getEntities/filterTest.ts
@@ -4,9 +4,9 @@ import Facade from '../../Facade';
 import Pagination from '../../types/Pagination';
 import Sort from '../../types/Sort';
 import filterTest, { firstEntity, secondEntity } from '../utils/filterTest';
-import { TestEntity, TestId } from '../utils/testEntity';
+import { TestEntity } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   const sort: Sort<TestEntity> = {};
   const pagination: Pagination = { cursor: undefined, forward: true, limit: 2 };
 

--- a/src/tests/getEntities/paginationTest.ts
+++ b/src/tests/getEntities/paginationTest.ts
@@ -5,13 +5,13 @@ import Cursor from '../../types/Cursor';
 import Filter from '../../types/Filter';
 import Pagination from '../../types/Pagination';
 import Sort from '../../types/Sort';
-import { TestEntity, testEntity, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
-  const firstId = { id: 'test_id_1' };
-  const secondId = { id: 'test_id_2' };
-  const firstEntity = { ...testEntity, ...firstId };
-  const secondEntity = { ...testEntity, ...secondId };
+export default (facade: Facade<TestEntity>) => {
+  const firstId = 'test_id_1';
+  const secondId = 'test_id_2';
+  const firstEntity = { ...testEntity, id: firstId };
+  const secondEntity = { ...testEntity, id: secondId };
   const sort: Sort<TestEntity> = { id: true };
   const filter: Filter<TestEntity> = {};
 

--- a/src/tests/getEntities/sortTest.ts
+++ b/src/tests/getEntities/sortTest.ts
@@ -4,13 +4,13 @@ import Facade from '../../Facade';
 import Filter from '../../types/Filter';
 import Pagination from '../../types/Pagination';
 import Sort from '../../types/Sort';
-import { TestEntity, testEntity, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
-  const firstId = { id: 'test_id_1' };
-  const secondId = { id: 'test_id_2' };
-  const firstEntity = { ...testEntity, ...firstId, stringProp: 'a', numberProp: 1 };
-  const secondEntity = { ...testEntity, ...secondId, stringProp: 'b', numberProp: 2 };
+export default (facade: Facade<TestEntity>) => {
+  const firstId = 'test_id_1';
+  const secondId = 'test_id_2';
+  const firstEntity = { ...testEntity, id: firstId, stringProp: 'a', numberProp: 1 };
+  const secondEntity = { ...testEntity, id: secondId, stringProp: 'b', numberProp: 2 };
 
   const assertSort = async (sortedEntities: TestEntity[], sort: Sort<TestEntity>) => {
     const filter: Filter<TestEntity> = {};

--- a/src/tests/getEntities/test.ts
+++ b/src/tests/getEntities/test.ts
@@ -1,11 +1,11 @@
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import Facade from '../../Facade';
-import { TestEntity, TestId } from '../utils/testEntity';
+import { TestEntity } from '../utils/testEntity';
 import filterTest from './filterTest';
 import paginationTest from './paginationTest';
 import sortTest from './sortTest';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('getEntities', () => {
     filterTest(facade);
     paginationTest(facade);

--- a/src/tests/getEntity/test.ts
+++ b/src/tests/getEntity/test.ts
@@ -3,9 +3,9 @@ import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import MissingEntityError from '../../errors/MissingEntityError';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('getEntity', () => {
     it('should error when identifier does not exist', async () => {
       const promise = facade.getEntity({ id: testId });

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -9,9 +9,9 @@ import patchEntityTest from './patchEntity/test';
 import removeEntitiesTest from './removeEntities/test';
 import removeEntityTest from './removeEntity/test';
 import upsertEntityTest from './upsertEntity/test';
-import { TestEntity, TestId } from './utils/testEntity';
+import { TestEntity } from './utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('facade', () => {
     beforeEach(async () => {
       await facade.removeEntities({ filter: {} });

--- a/src/tests/overwriteEntity/test.ts
+++ b/src/tests/overwriteEntity/test.ts
@@ -3,9 +3,9 @@ import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import MissingEntityError from '../../errors/MissingEntityError';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('overwriteEntity', () => {
     it('should error when identifier does not exist', async () => {
       const promise = facade.overwriteEntity({ id: testId, entity: testEntity });
@@ -14,8 +14,8 @@ export default (facade: Facade<TestId, TestEntity>) => {
 
     it('should overwrite when identifier does exist', async () => {
       const testOverwrite: TestEntity = {
-        ...testId,
         booleanProp: false,
+        id: testId,
         numberProp: 2,
         stringProp: 'test_string_prop_overwrite',
       };

--- a/src/tests/patchEntity/test.ts
+++ b/src/tests/patchEntity/test.ts
@@ -3,9 +3,9 @@ import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import MissingEntityError from '../../errors/MissingEntityError';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('patchEntity', () => {
     const assertPatch = async (testPatch: Partial<TestEntity>) => {
       const { entity: patchedEntity } = await facade.patchEntity({

--- a/src/tests/removeEntities/test.ts
+++ b/src/tests/removeEntities/test.ts
@@ -4,9 +4,9 @@ import Facade from '../../Facade';
 import Pagination from '../../types/Pagination';
 import Sort from '../../types/Sort';
 import filterTest, { firstEntity, secondEntity } from '../utils/filterTest';
-import { TestEntity, TestId } from '../utils/testEntity';
+import { TestEntity } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('removeEntities', () => {
     const sort: Sort<TestEntity> = {};
     const pagination: Pagination = { cursor: undefined, forward: true, limit: 2 };

--- a/src/tests/removeEntity/test.ts
+++ b/src/tests/removeEntity/test.ts
@@ -2,9 +2,9 @@ import * as assertRejects from 'assert-rejects';
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import MissingEntityError from '../../errors/MissingEntityError';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('removeEntity', () => {
     it('should error when identifier does not exist', async () => {
       const promise = facade.removeEntity({ id: testId });

--- a/src/tests/upsertEntity/test.ts
+++ b/src/tests/upsertEntity/test.ts
@@ -1,9 +1,9 @@
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import Facade from '../../Facade';
-import { TestEntity, testEntity, testId, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity, testId } from '../utils/testEntity';
 
-export default (facade: Facade<TestId, TestEntity>) => {
+export default (facade: Facade<TestEntity>) => {
   describe('upsertEntity', () => {
     it('should create when identifier does not exist', async () => {
       const { entity: createdEntity } = await facade.upsertEntity({
@@ -17,8 +17,8 @@ export default (facade: Facade<TestId, TestEntity>) => {
 
     it('should overwrite when identifier does exist', async () => {
       const testOverwrite: TestEntity = {
-        ...testId,
         booleanProp: false,
+        id: testId,
         numberProp: 2,
         stringProp: 'test_string_prop_overwrite',
       };

--- a/src/tests/utils/filterTest.ts
+++ b/src/tests/utils/filterTest.ts
@@ -1,20 +1,20 @@
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import Facade from '../../Facade';
 import Filter from '../../types/Filter';
-import { TestEntity, testEntity, TestId } from '../utils/testEntity';
+import { TestEntity, testEntity } from '../utils/testEntity';
 
 export type FilterAsserter = (filter: Filter<TestEntity>) => Promise<void>;
 
 export interface Opts {
-  readonly facade: Facade<TestId, TestEntity>;
+  readonly facade: Facade<TestEntity>;
   readonly assertFirstEntityFilter: FilterAsserter;
   readonly assertNoEntityFilter: FilterAsserter;
   readonly assertAllEntitiesFilter: FilterAsserter;
 }
-const firstId = { id: 'test_id_1' };
-const secondId = { id: 'test_id_2' };
-export const firstEntity = { ...testEntity, ...firstId, stringProp: 'a', numberProp: 1 };
-export const secondEntity = { ...testEntity, ...secondId, stringProp: 'b', numberProp: 2 };
+const firstId = 'test_id_1';
+const secondId = 'test_id_2';
+export const firstEntity = { ...testEntity, id: firstId, stringProp: 'a', numberProp: 1 };
+export const secondEntity = { ...testEntity, id: secondId, stringProp: 'b', numberProp: 2 };
 
 export default (opts: Opts) => {
   const createTestEntities = async () => {

--- a/src/tests/utils/testEntity.ts
+++ b/src/tests/utils/testEntity.ts
@@ -1,20 +1,16 @@
-export interface TestId {
-  readonly id: string;
-}
+import Entity from '../../types/Entity';
 
-export interface TestEntity extends TestId {
+export interface TestEntity extends Entity {
   readonly stringProp: string;
   readonly numberProp: number;
   readonly booleanProp: boolean;
 }
 
-export const testId: TestId = {
-  id: 'test_id',
-};
+export const testId = 'test_id';
 
 export const testEntity: TestEntity = {
-  ...testId,
   booleanProp: true,
+  id: testId,
   numberProp: 1,
   stringProp: 'test_string_prop',
 };

--- a/src/types/Entity.ts
+++ b/src/types/Entity.ts
@@ -1,0 +1,3 @@
+export default interface Entity {
+  readonly id: string;
+}

--- a/src/types/Filter.ts
+++ b/src/types/Filter.ts
@@ -1,3 +1,5 @@
+import Entity from './Entity';
+
 export interface PropFilter<Prop> {
   readonly $gt?: Prop;
   readonly $gte?: Prop;
@@ -10,19 +12,19 @@ export interface PropFilter<Prop> {
   readonly $not?: PropFilter<Prop>;
 }
 
-export type EntityFilter<Entity> = {
-  readonly [P in keyof Entity]?: Entity[P] | PropFilter<Entity[P]>;
+export type EntityFilter<E extends Entity> = {
+  readonly [P in keyof E]?: E[P] | PropFilter<E[P]>;
 };
 
-export interface ConditionFilter<Entity> {
-  readonly $and?: Filter<Entity>[];
-  readonly $or?: Filter<Entity>[];
-  readonly $nor?: Filter<Entity>[];
+export interface ConditionFilter<E extends Entity> {
+  readonly $and?: Filter<E>[];
+  readonly $or?: Filter<E>[];
+  readonly $nor?: Filter<E>[];
 }
 
-export type Filter<Entity> = (
-  EntityFilter<Entity> &
-  ConditionFilter<Entity>
+export type Filter<E extends Entity> = (
+  EntityFilter<E> &
+  ConditionFilter<E>
 );
 
 export default Filter;

--- a/src/types/Sort.ts
+++ b/src/types/Sort.ts
@@ -1,5 +1,7 @@
-type Sort<Entity> = {
-  readonly [P in keyof Entity]?: boolean;
+import Entity from './Entity';
+
+type Sort<E extends Entity> = {
+  readonly [P in keyof E]?: boolean;
 };
 
 export default Sort;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,0 @@
-import CursorType from './Cursor';
-import FilterType from './Filter';
-import PaginationType from './Pagination';
-import SortType from './Sort';
-
-export type Cursor = CursorType;
-export type Filter<Entity> = FilterType<Entity>;
-export type Paginatior = PaginationType;
-export type Sort<Entity> = SortType<Entity>;

--- a/src/utils/createCursorFromEntity/index.ts
+++ b/src/utils/createCursorFromEntity/index.ts
@@ -1,14 +1,15 @@
 import * as btoa from 'btoa';
 import { get, set } from 'lodash';
 import Cursor from '../../types/Cursor';
+import Entity from '../../types/Entity';
 import Sort from '../../types/Sort';
 
-export default <Entity>(entity: Entity | undefined, sort: Sort<Entity>): Cursor => {
+export default <E extends Entity>(entity: E | undefined, sort: Sort<E>): Cursor => {
   if (entity === undefined) {
     return undefined;
   }
   const sortKeys = Object.keys(sort);
-  const cursorResult = sortKeys.reduce<Partial<Entity>>((result, sortKey) => {
+  const cursorResult = sortKeys.reduce<Partial<E>>((result, sortKey) => {
     return set(result, sortKey, get(entity, sortKey));
   }, {});
   return btoa(JSON.stringify(cursorResult));

--- a/src/utils/createPaginationFilter/index.test.ts
+++ b/src/utils/createPaginationFilter/index.test.ts
@@ -1,12 +1,14 @@
 import 'mocha'; // tslint:disable-line:no-import-side-effect
 import * as assert from 'power-assert';
 import { TestEntity, testEntity } from '../../tests/utils/testEntity';
+import { Filter } from '../../types/Filter';
 import Pagination from '../../types/Pagination';
+import Sort from '../../types/Sort';
 import createCursorFromEntity from '../createCursorFromEntity';
 import createPaginationFilter from './index';
 
 describe('createCursorFromEntity', () => {
-  const sort = { id: true };
+  const sort: Sort<TestEntity> = { id: true, booleanProp: false };
 
   it('should return empty filter when the cursor is undefined', () => {
     const pagination: Pagination = { cursor: undefined, forward: true, limit: 1 };
@@ -19,7 +21,8 @@ describe('createCursorFromEntity', () => {
     const cursor = createCursorFromEntity<TestEntity>(testEntity, sort);
     const pagination: Pagination = { cursor, forward: true, limit: 1 };
     const actualResult = createPaginationFilter<TestEntity>(pagination, sort);
-    const expectedResult = {
+    const expectedResult: Filter<TestEntity> = {
+      booleanProp: { $lt: testEntity.booleanProp },
       id: { $gt: testEntity.id },
     };
     assert.deepEqual(actualResult, expectedResult);
@@ -29,7 +32,8 @@ describe('createCursorFromEntity', () => {
     const cursor = createCursorFromEntity<TestEntity>(testEntity, sort);
     const pagination: Pagination = { cursor, forward: false, limit: 1 };
     const actualResult = createPaginationFilter<TestEntity>(pagination, sort);
-    const expectedResult = {
+    const expectedResult: Filter<TestEntity> = {
+      booleanProp: { $gt: testEntity.booleanProp },
       id: { $lt: testEntity.id },
     };
     assert.deepEqual(actualResult, expectedResult);

--- a/src/utils/createPaginationFilter/index.test.ts
+++ b/src/utils/createPaginationFilter/index.test.ts
@@ -22,7 +22,7 @@ describe('createCursorFromEntity', () => {
     const pagination: Pagination = { cursor, forward: true, limit: 1 };
     const actualResult = createPaginationFilter<TestEntity>(pagination, sort);
     const expectedResult: Filter<TestEntity> = {
-      booleanProp: { $lt: testEntity.booleanProp },
+      booleanProp: { $lte: testEntity.booleanProp },
       id: { $gt: testEntity.id },
     };
     assert.deepEqual(actualResult, expectedResult);
@@ -33,7 +33,7 @@ describe('createCursorFromEntity', () => {
     const pagination: Pagination = { cursor, forward: false, limit: 1 };
     const actualResult = createPaginationFilter<TestEntity>(pagination, sort);
     const expectedResult: Filter<TestEntity> = {
-      booleanProp: { $gt: testEntity.booleanProp },
+      booleanProp: { $gte: testEntity.booleanProp },
       id: { $lt: testEntity.id },
     };
     assert.deepEqual(actualResult, expectedResult);

--- a/src/utils/createPaginationFilter/index.ts
+++ b/src/utils/createPaginationFilter/index.ts
@@ -18,9 +18,17 @@ export default <E extends Entity>(pagination: Pagination, sort: Sort<E>): Filter
   const filter = mapValues(cursorObj, (cursorValue, sortKey) => {
     const forward = !xor(get(sort, sortKey), pagination.forward);
     if (forward) {
-      return { $gt: cursorValue };
+      if (sortKey === 'id') {
+        return { $gt: cursorValue };
+      } else {
+        return { $gte: cursorValue };
+      }
     } else {
-      return { $lt: cursorValue };
+      if (sortKey === 'id') {
+        return { $lt: cursorValue };
+      } else {
+        return { $lte: cursorValue };
+      }
     }
   });
   return filter as any as Filter<E>;

--- a/src/utils/createPaginationFilter/index.ts
+++ b/src/utils/createPaginationFilter/index.ts
@@ -1,5 +1,6 @@
 import * as atob from 'atob';
 import { get, mapValues } from 'lodash';
+import Entity from '../../types/Entity';
 // tslint:disable-next-line:no-unused
 import Filter, { ConditionFilter, EntityFilter } from '../../types/Filter';
 import Pagination from '../../types/Pagination';
@@ -9,7 +10,7 @@ const xor = (conditionA: boolean, conditionB: boolean) => {
   return (conditionA && !conditionB) || (!conditionA && conditionB);
 };
 
-export default <Entity>(pagination: Pagination, sort: Sort<Entity>): Filter<Entity> => {
+export default <E extends Entity>(pagination: Pagination, sort: Sort<E>): Filter<E> => {
   if (pagination.cursor === undefined) {
     return {};
   }
@@ -22,5 +23,5 @@ export default <Entity>(pagination: Pagination, sort: Sort<Entity>): Filter<Enti
       return { $lt: cursorValue };
     }
   });
-  return filter as any as Filter<Entity>;
+  return filter as any as Filter<E>;
 };


### PR DESCRIPTION
The Id interface is one of the first questions people ask about this which may highlight some confusion about it, hence I've decided to remove it and just enforce a single `id` property on entities. Mongo does this anyway and other frameworks also enforce this like FeathersJS.